### PR TITLE
Check for correct header for swapping to MVSC Macro

### DIFF
--- a/include/aegis/impl/core.cpp
+++ b/include/aegis/impl/core.cpp
@@ -1659,7 +1659,8 @@ AEGIS_DECL void core::ws_guild_member_update(const json & result, shards::shard 
 
     if (_member == nullptr)
     {
-#ifdef WIN32
+		
+#ifdef _MSC_VER
         log->critical("Shard#{} : Error in [{}] _member == nullptr", _shard->get_id(), __FUNCSIG__);
 #else
         log->critical("Shard#{} : Error in [{}] _member == nullptr", _shard->get_id(), __PRETTY_FUNCTION__);
@@ -1668,7 +1669,7 @@ AEGIS_DECL void core::ws_guild_member_update(const json & result, shards::shard 
     }
     if (_guild == nullptr)
     {
-#ifdef WIN32
+#ifdef _MSC_VER
         log->critical("Shard#{} : Error in [{}] _guild == nullptr", _shard->get_id(), __FUNCSIG__);
 #else
         log->critical("Shard#{} : Error in [{}] _guild == nullptr", _shard->get_id(), __PRETTY_FUNCTION__);


### PR DESCRIPTION
Checking for definition of WIN32 will cause all windows compilation on windows to use the \_\_FUNCSIG__ macro over the \_\_PRETTY_FUNCTION__ macro, even though \_\_FUNCSIG__ is an MSVC-exclusive macro. Checking instead for _MSC_VER will correctly only swap the macro when compiling with MSVC