### PR TITLE
on deletion of a channel or guild, it is possible for aegis to crash

### DIFF
--- a/include/aegis/impl/core.cpp
+++ b/include/aegis/impl/core.cpp
@@ -1321,7 +1321,7 @@ AEGIS_DECL void core::ws_guild_delete(const json & result, shards::shard * _shar
         _guild->unavailable = obj.unavailable;
 #endif
 
-        std::unique_lock<shared_mutex> l(_guild_m);
+        //std::unique_lock<shared_mutex> l(_guild_m);
         //kicked or left
         //websocket_o.set_timer(5000, [this, id, _shard](const asio::error_code & ec)
         //{

--- a/include/aegis/impl/core.cpp
+++ b/include/aegis/impl/core.cpp
@@ -1562,11 +1562,11 @@ AEGIS_DECL void core::ws_channel_delete(const json & result, shards::shard * _sh
         * Don't keep this lock in scope when we reach it, otherwise bad stuff
         * will happen. - CraigE
         */
-       do {
+       {
                 std::unique_lock<shared_mutex> l2(_channel_m, std::defer_lock);
                 std::lock(l, l2);
                 _guild->_remove_channel(channel_id);
-       } while (false);
+       }
         remove_channel(channel_id);
     }
 

--- a/include/aegis/impl/core.cpp
+++ b/include/aegis/impl/core.cpp
@@ -1558,9 +1558,15 @@ AEGIS_DECL void core::ws_channel_delete(const json & result, shards::shard * _sh
         if (_channel == nullptr)//TODO: errors
             return;
         std::unique_lock<shared_mutex> l(_channel->mtx(), std::defer_lock);
-        std::unique_lock<shared_mutex> l2(_channel_m, std::defer_lock);
-        std::lock(l, l2);
-        _guild->_remove_channel(channel_id);
+       /* FIX NOTE: _channel_m is also locked by core::remove_channel().
+        * Don't keep this lock in scope when we reach it, otherwise bad stuff
+        * will happen. - CraigE
+        */
+       do {
+                std::unique_lock<shared_mutex> l2(_channel_m, std::defer_lock);
+                std::lock(l, l2);
+                _guild->_remove_channel(channel_id);
+       } while (false);
         remove_channel(channel_id);
     }
 


### PR DESCRIPTION
Due to two functions in core.cpp locking the same mutex, a deadlock can occur when deleting a channel from a guild.

The fix below fixes the issue for me.

Please merge in or use to build your own fix for the issue.