### PR TITLE
Fix race condition during creation of `_self`

### DIFF
--- a/include/aegis/impl/core.cpp
+++ b/include/aegis/impl/core.cpp
@@ -677,8 +677,7 @@ AEGIS_DECL void core::process_ready(const json & d, shards::shard * _shard)
             mention = ss.str();
         }
 
-        auto m = std::make_unique<user>(user_id);
-        _self = m.get();
+        _self = user_create(user_id);
         users.emplace(user_id, std::move(m));
         _self->_member_id = user_id;
         _self->_is_bot = true;


### PR DESCRIPTION
A race condition existed where the bot's `user` was created from `core::process_ready`, emplaced in `users`, and then another thread emplaced a user with the same ID. This was possible because in `core::process_ready` the common mutex guarding `users` was not acquired prior to emplacing our user.

Now the bot `user` is created as all users are, by using `user_create`. This will acquire the common mutex, and prevent such a race condition.