### PR TITLE
Fix race condition in `future`

### DIFF
--- a/include/aegis/futures.hpp
+++ b/include/aegis/futures.hpp
@@ -561,8 +561,7 @@ public:
         , _global_m(x._global_m)
     {
         std::atomic_thread_fence(std::memory_order_acquire);
-        //std::lock_guard<std::recursive_mutex> gl(internal::_global_m);
-        //TODO: this needs a lock or l2 lock has a chance of segfault
+        std::lock_guard<std::recursive_mutex> gl(*_global_m);
         if (x._future)
         {
             std::unique_lock<std::recursive_mutex> l(_m, std::defer_lock);
@@ -790,6 +789,7 @@ private:
         }
         else
         {
+            std::lock_guard<std::recursive_mutex> gl(*_global_m);
             std::unique_lock<std::recursive_mutex> l(_m, std::defer_lock);
             std::unique_lock<std::recursive_mutex> l2(_promise->_m, std::defer_lock);
             std::lock(l, l2);
@@ -805,6 +805,7 @@ private:
         auto st = state();
         if (_promise)
         {
+            std::lock_guard<std::recursive_mutex> gl(*_global_m);
             std::lock_guard<std::recursive_mutex> l(_promise->_m);
             if (!_promise)
                 goto NOTREALLYTHERE;
@@ -859,6 +860,7 @@ public:
         x._promise = nullptr;
         if (_promise)
         {
+            std::lock_guard<std::recursive_mutex> gl(*_global_m);
             std::lock_guard<std::recursive_mutex> l(_promise->_m);
             _promise->_future = this;
         }
@@ -1047,6 +1049,7 @@ public:
         }
         else
         {
+            std::lock_guard<std::recursive_mutex> gl(*_global_m);
             _promise->_future = nullptr;
             *_promise = std::move(pr);
             _promise = nullptr;


### PR DESCRIPTION
`future`'s member `_promise` is changed from a number of methods (to `nullptr`, or otherwise). This change places all of the setting operations inside of a global mutex. This will prevent `_promise` from becoming `nullptr` while it's potentially being used by another thread.

The behavior of when `_promise` is being assigned from multiple threads will no longer cause memory access violation. The `_promise` will no longer be able to change out from under a thread while it's in use.