### PR TITLE
Add get_overwrites and get_overwrites_nocopy to channels

### DIFF
--- a/include/aegis/channel.hpp
+++ b/include/aegis/channel.hpp
@@ -529,6 +529,8 @@ public:
     {
         return edit_channel_permissions(obj._overwrite_id, obj._allow, obj._deny, obj._type);
     }
+    
+    #if !defined(AEGIS_DISABLE_ALL_CACHE)
 
     /// Get permission overwrites for this channel
     /**
@@ -538,7 +540,7 @@ public:
     {
         return overrides;
     }
-
+    
     /// Get permission overwrites for this channel
     /**
     * @returns A reference to an unordered map of permission overwrites for this channel
@@ -547,6 +549,8 @@ public:
     {
         return overrides;
     }
+
+    #endif
 
     /// Get active channel invites
     /**

--- a/include/aegis/channel.hpp
+++ b/include/aegis/channel.hpp
@@ -18,7 +18,6 @@
 #include "aegis/gateway/objects/messages.hpp"
 #include "aegis/gateway/objects/permission_overwrite.hpp"
 #include "aegis/gateway/objects/channel.hpp"
-
 #include <shared_mutex>
 #include "aegis/futures.hpp"
 

--- a/include/aegis/channel.hpp
+++ b/include/aegis/channel.hpp
@@ -15,8 +15,10 @@
 #include "aegis/ratelimit/ratelimit.hpp"
 #include "aegis/permission.hpp"
 #include "aegis/snowflake.hpp"
+#include "aegis/gateway/objects/messages.hpp"
 #include "aegis/gateway/objects/permission_overwrite.hpp"
 #include "aegis/gateway/objects/channel.hpp"
+
 #include <shared_mutex>
 #include "aegis/futures.hpp"
 
@@ -526,6 +528,24 @@ public:
     AEGIS_DECL aegis::future<rest::rest_reply> edit_channel_permissions(edit_channel_permissions_t obj)
     {
         return edit_channel_permissions(obj._overwrite_id, obj._allow, obj._deny, obj._type);
+    }
+
+    /// Get permission overwrites for this channel
+    /**
+    * @returns COPY OF an unordered map of permission overwrites for this channel
+    */
+    std::unordered_map<int64_t, gateway::objects::permission_overwrite> get_overwrites()
+    {
+        return overrides;
+    }
+
+    /// Get permission overwrites for this channel
+    /**
+    * @returns A reference to an unordered map of permission overwrites for this channel
+    */
+    const std::unordered_map<int64_t, gateway::objects::permission_overwrite>& get_overwrites_nocopy()
+    {
+        return overrides;
     }
 
     /// Get active channel invites


### PR DESCRIPTION
Already had this in my local copy of the lib, figure it'd be useful to others as well.

Added include for messages.hpp since MSVC gives an undefined function error for get_messages() when compiling with `AEGIS_DYN_LIB` enabled, since the messages object is used as the return type. Should've already been here for that reason anyways, so should be a minor change.