### PR TITLE
Fix permission serialization

### DIFF
--- a/include/aegis/impl/permission.cpp
+++ b/include/aegis/impl/permission.cpp
@@ -26,7 +26,7 @@ AEGIS_DECL void from_json(const nlohmann::json& j, permission& s)
 
 AEGIS_DECL void to_json(nlohmann::json& j, const permission& s)
 {
-    j = nlohmann::json{ static_cast<int64_t>(s) };
+    j = std::to_string(static_cast<int64_t>(s));
 }
 /// \endcond
 


### PR DESCRIPTION
Discord docs [here](https://discord.com/developers/docs/topics/permissions) state that as of api v8, permissions are no longer to be serialized as numbers but rather as strings. However, as I noticed when attempting to use `create_guild_role` recently, this restriction appeared to be in place for v6 as well with my bot receiving a `400 Bad Request` response. Upon further inspection, however, I found that v6 is supposed to support permission serialization as both strings and numbers. So, taking a look at the library, I found that permissions were actually being serialized as an array of ints. As such, I think this fix should be pulled promptly to avoid problems currently and in the future, considering v6 supports string serialization and v8 will require it.