### PR TITLE
Finish implementation of invites and emojis

### DIFF
--- a/include/aegis/gateway/objects/bans.hpp
+++ b/include/aegis/gateway/objects/bans.hpp
@@ -1,5 +1,5 @@
 //
-// ban.hpp
+// bans.hpp
 // ********
 //
 // Copyright (c) 2020 Sharon Fox (sharon at xandium dot io)

--- a/include/aegis/gateway/objects/emoji.hpp
+++ b/include/aegis/gateway/objects/emoji.hpp
@@ -55,6 +55,15 @@ struct emoji
         return id ? fmt::format("<{}:{}:{}>", animated ? "a" : "", name, id) : name;
     }
 
+    /// Formats the emoji for use as a reaction
+    /**
+    * @returns string of reaction-formatted emoji
+    */
+    std::string reaction() const noexcept
+    {
+        return id ? fmt::format("{}:{}", name, id) : name;
+    }
+
     snowflake id; /**< Emoji ID */
     std::string name; /**< Emoji Name */
     std::vector<snowflake> roles; /**< Roles this emoji is whitelisted to */

--- a/include/aegis/gateway/objects/emoji.hpp
+++ b/include/aegis/gateway/objects/emoji.hpp
@@ -22,9 +22,30 @@ namespace gateway
 namespace objects
 {
 
+struct emoji;
+
+/// \cond TEMPLATES
+void from_json(const nlohmann::json& j, emoji& m);
+void to_json(nlohmann::json& j, const emoji& m);
+/// \endcond
+
 /// Discord Emoji Object
 struct emoji
 {
+    emoji(const std::string& _json, aegis::core* bot) noexcept
+    {
+        from_json(nlohmann::json::parse(_json), *this);
+    }
+
+    emoji(const nlohmann::json& _json, aegis::core* bot) noexcept
+    {
+        from_json(_json, *this);
+    }
+
+    emoji(aegis::core* bot) noexcept {}
+
+    emoji() noexcept {}
+
     /// Formats the emoji for adding to a message
     /**
      * @returns string of formatted emoji

--- a/include/aegis/gateway/objects/invite.hpp
+++ b/include/aegis/gateway/objects/invite.hpp
@@ -63,7 +63,7 @@ struct invite
     snowflake _channel; /**< Channel this invite is for */
     snowflake inviter; /**< User that created the invite */
     snowflake target_user; /**< Target user for this invite */
-    target_user_type target_user_type = STREAM; /**< Type of user target for this invite */
+    target_user_type target_type = STREAM; /**< Type of user target for this invite */
     int32_t approximate_presence_count = 0; /**< Approximate count of online members of guild, requires target_user be set */
     int32_t approximate_member_count = 0; /**< Approximate count of total members of guild */
     invite_metadata_t metadata; /**< Extra information about invite */

--- a/include/aegis/gateway/objects/invite.hpp
+++ b/include/aegis/gateway/objects/invite.hpp
@@ -1,6 +1,6 @@
 //
 // invite.hpp
-// *********
+// **********
 //
 // Copyright (c) 2020 Sharon Fox (sharon at xandium dot io)
 //

--- a/include/aegis/gateway/objects/invite.hpp
+++ b/include/aegis/gateway/objects/invite.hpp
@@ -82,7 +82,7 @@ inline void from_json(const nlohmann::json& j, invite& m)
     if (j.count("target_user") && !j["target_user"].is_null())
         m.target_user = j["target_user"]["id"];
     if (j.count("target_user_type") && !j["target_user_type"].is_null())
-        m.target_user_type = j["target_user_type"];
+        m.target_type = j["target_user_type"];
     if (j.count("approximate_presence_count") && !j["approximate_presence_count"].is_null())
         m.approximate_presence_count = j["approximate_presence_count"];
     if (j.count("approximate_member_count") && !j["approximate_member_count"].is_null())
@@ -108,7 +108,7 @@ inline void to_json(nlohmann::json& j, const invite& m)
     j["channel"] = m._channel;
     j["inviter"] = m.inviter;
     j["target_user"] = m.target_user;
-    j["target_user_type"] = m.target_user_type;
+    j["target_user_type"] = m.target_type;
     j["approximate_presence_count"] = m.approximate_presence_count;
     j["approximate_member_count"] = m.approximate_member_count;
     

--- a/include/aegis/gateway/objects/invite.hpp
+++ b/include/aegis/gateway/objects/invite.hpp
@@ -1,0 +1,128 @@
+//
+// invite.hpp
+// *********
+//
+// Copyright (c) 2020 Sharon Fox (sharon at xandium dot io)
+//
+// Distributed under the MIT License. (See accompanying file LICENSE)
+//
+
+#pragma once
+
+#include "aegis/config.hpp"
+#include "aegis/snowflake.hpp"
+#include <nlohmann/json.hpp>
+
+namespace aegis
+{
+
+namespace gateway
+{
+
+namespace objects
+{
+
+enum target_user_type {
+    STREAM = 1
+};
+
+struct invite_metadata_t {
+    int32_t uses; /**< # of times this invite has been used */
+    int32_t max_uses; /**< Max # of times this invite can be used */
+    int32_t max_age; /**< Duration (in seconds) after which the invite expires */
+    bool temporary = false; /**< Whether this invite only grants temporary membership */
+    std::string created_at; /**< ISO8601 timestamp of when this invite was created */
+};
+
+struct invite;
+
+/// \cond TEMPLATES
+void from_json(const nlohmann::json& j, invite& m);
+void to_json(nlohmann::json& j, const invite& m);
+/// \endcond
+
+/// Discord Invite Object
+struct invite
+{
+    invite(const std::string& _json, aegis::core* bot) noexcept
+    {
+        from_json(nlohmann::json::parse(_json), *this);
+    }
+
+    invite(const nlohmann::json& _json, aegis::core* bot) noexcept
+    {
+        from_json(_json, *this);
+    }
+
+    invite(aegis::core* bot) noexcept {}
+
+    invite() noexcept {}
+
+    std::string code; /**< Invite code (unique ID) */
+    snowflake _guild; /**< Guild this invite is for */
+    snowflake _channel; /**< Channel this invite is for */
+    snowflake inviter; /**< User that created the invite */
+    snowflake target_user; /**< Target user for this invite */
+    target_user_type target_user_type = STREAM; /**< Type of user target for this invite */
+    int32_t approximate_presence_count = 0; /**< Approximate count of online members of guild, requires target_user be set */
+    int32_t approximate_member_count = 0; /**< Approximate count of total members of guild */
+    invite_metadata_t metadata; /**< Extra information about invite */
+};
+
+/// \cond TEMPLATES
+inline void from_json(const nlohmann::json& j, invite& m)
+{
+    m.code = j["code"];
+    if (j.count("guild") && !j["guild"].is_null())
+        m._guild = j["guild"]["id"];
+    if (j.count("channel") && !j["channel"].is_null())
+        m._channel = j["channel"]["id"];
+    if (j.count("inviter") && !j["inviter"].is_null())
+        m.inviter = j["inviter"]["id"];
+    if (j.count("target_user") && !j["target_user"].is_null())
+        m.target_user = j["target_user"]["id"];
+    if (j.count("target_user_type") && !j["target_user_type"].is_null())
+        m.target_user_type = j["target_user_type"];
+    if (j.count("approximate_presence_count") && !j["approximate_presence_count"].is_null())
+        m.approximate_presence_count = j["approximate_presence_count"];
+    if (j.count("approximate_member_count") && !j["approximate_member_count"].is_null())
+        m.approximate_member_count = j["approximate_member_count"];
+
+    // Metadata
+    if (j.count("uses") && !j["uses"].is_null())
+        m.metadata.uses = j["uses"];
+    if (j.count("max_uses") && !j["max_uses"].is_null())
+        m.metadata.max_uses = j["max_uses"];
+    if (j.count("max_age") && !j["max_age"].is_null())
+        m.metadata.max_age = j["max_age"];
+    if (j.count("temporary") && !j["temporary"].is_null())
+        m.metadata.temporary = j["temporary"];
+    if (j.count("created_at") && !j["created_at"].is_null())
+        m.metadata.created_at = j["created_at"];
+}
+
+inline void to_json(nlohmann::json& j, const invite& m)
+{
+    j["code"] = m.code;
+    j["guild"] = m._guild;
+    j["channel"] = m._channel;
+    j["inviter"] = m.inviter;
+    j["target_user"] = m.target_user;
+    j["target_user_type"] = m.target_user_type;
+    j["approximate_presence_count"] = m.approximate_presence_count;
+    j["approximate_member_count"] = m.approximate_member_count;
+    
+    // Metadata
+    j["uses"] = m.metadata.uses;
+    j["max_uses"] = m.metadata.max_uses;
+    j["max_age"] = m.metadata.max_age;
+    j["temporary"] = m.metadata.temporary;
+    j["created_at"] = m.metadata.created_at;
+}
+/// \endcond
+
+}
+
+}
+
+}

--- a/include/aegis/gateway/objects/invites.hpp
+++ b/include/aegis/gateway/objects/invites.hpp
@@ -1,0 +1,97 @@
+//
+// invites.hpp
+// ********
+//
+// Copyright (c) 2020 Sharon Fox (sharon at xandium dot io)
+//
+// Distributed under the MIT License. (See accompanying file LICENSE)
+//
+
+#pragma once
+
+#include "aegis/config.hpp"
+#include "aegis/snowflake.hpp"
+#include "aegis/permission.hpp"
+#include "aegis/user.hpp"
+#include "invite.hpp"
+#include <nlohmann/json.hpp>
+#include <vector>
+
+namespace aegis
+{
+
+namespace gateway
+{
+
+namespace objects
+{
+
+struct invites;
+
+/// \cond TEMPLATES
+void from_json(const nlohmann::json& j, invites& m);
+void to_json(nlohmann::json& j, const invites& m);
+/// \endcond
+
+/// Stores info pertaining to guild invites
+struct invites
+{
+    invites(const std::string& _json, aegis::core* bot) noexcept
+    {
+        from_json(nlohmann::json::parse(_json), *this);
+    }
+
+    invites(const nlohmann::json& _json, aegis::core* bot) noexcept
+    {
+        from_json(_json, *this);
+    }
+
+    invites(aegis::core* bot) noexcept {}
+
+    invites() noexcept {}
+
+    std::vector<aegis::gateway::objects::invite>::iterator begin()
+    {
+        return _invites.begin();
+    }
+
+    std::vector<aegis::gateway::objects::invite>::iterator end()
+    {
+        return _invites.end();
+    }
+
+    std::vector<aegis::gateway::objects::invite>::reverse_iterator rbegin()
+    {
+        return _invites.rbegin();
+    }
+
+    std::vector<aegis::gateway::objects::invite>::reverse_iterator rend()
+    {
+        return _invites.rend();
+    }
+
+    std::vector<aegis::gateway::objects::invite> _invites; /**< array of invites */
+
+};
+
+/// \cond TEMPLATES
+inline void from_json(const nlohmann::json& j, invites& m)
+{
+    if (j.size())
+        for (const auto& _invite : j)
+            m._invites.push_back(_invite);
+}
+
+inline void to_json(nlohmann::json& j, const invites& m)
+{
+    if (!m._invites.empty())
+        for (const auto& _invite : m._invites)
+            j.push_back(_invite);
+}
+/// \endcond
+
+}
+
+}
+
+}

--- a/include/aegis/gateway/objects/invites.hpp
+++ b/include/aegis/gateway/objects/invites.hpp
@@ -1,6 +1,6 @@
 //
 // invites.hpp
-// ********
+// ***********
 //
 // Copyright (c) 2020 Sharon Fox (sharon at xandium dot io)
 //

--- a/include/aegis/guild.hpp
+++ b/include/aegis/guild.hpp
@@ -19,6 +19,8 @@
 #include "aegis/gateway/objects/member.hpp"
 #include "aegis/gateway/objects/ban.hpp"
 #include "aegis/gateway/objects/bans.hpp"
+#include "aegis/gateway/objects/invite.hpp"
+#include "aegis/gateway/objects/invites.hpp"
 #include <future>
 #include <asio.hpp>
 #include <shared_mutex>
@@ -633,11 +635,25 @@ public:
      */
     AEGIS_DECL aegis::future<rest::rest_reply> begin_guild_prune(int16_t days);
 
+    /// Get active guild invite
+    /**
+    * @param invite_code The invite code of the invite to retrieve
+    * @returns aegis::future<gateway::objects::invite>
+    */
+    AEGIS_DECL aegis::future<gateway::objects::invite> get_guild_invite(std::string invite_code);
+
     /// Get active guild invites
     /**
-     * @returns aegis::future<rest::rest_reply>
-     */
-    AEGIS_DECL aegis::future<rest::rest_reply> get_guild_invites();
+    * @returns aegis::future<gateway::objects::invites>
+    */
+    AEGIS_DECL aegis::future<gateway::objects::invites> get_guild_invites();
+
+    /// Delete active guild invite
+    /**
+    * @param invite_code The invite code of the invite to delete
+    * @returns aegis::future<rest::rest_reply>
+    */
+    AEGIS_DECL aegis::future<rest::rest_reply> delete_guild_invite(std::string invite_code);
 
     /// Get guild integrations
     /**
@@ -775,6 +791,17 @@ public:
         return std::move(_list);
     }
 
+    /// Obtain map of emojis
+    /**
+    * @returns std::unordered_map<snowflake, gateway::objects::emoji> COPY of emojis
+    */
+    std::unordered_map<snowflake, gateway::objects::emoji> get_emojis() const noexcept
+    {
+        std::shared_lock<shared_mutex> l(_m);
+        std::unordered_map<snowflake, gateway::objects::emoji> _list = emojis;
+        return std::move(_list);
+    }
+
     /// Obtain map of members - caller must lock guild._m to ensure no race conditions
     /**
      * @returns unordered_map<snowflake, user*> of members
@@ -791,6 +818,15 @@ public:
     const std::unordered_map<snowflake, gateway::objects::role> & get_roles_nocopy() const noexcept
     {
         return roles;
+    }
+
+    /// Obtain map of emojis - caller must lock guild._m to ensure no race conditions
+    /**
+    * @returns unordered_map<snowflake, gateway::objects::emoji> of emojis
+    */
+    const std::unordered_map<snowflake, gateway::objects::emoji>& get_emojis_nocopy() const noexcept
+    {
+        return emojis;
     }
 #endif
 

--- a/include/aegis/impl/guild.cpp
+++ b/include/aegis/impl/guild.cpp
@@ -999,16 +999,34 @@ AEGIS_DECL aegis::future<rest::rest_reply> guild::begin_guild_prune(int16_t days
     return aegis::make_exception_future(error::not_implemented);
 }
 
-/**\todo Incomplete. Signature may change
- */
-AEGIS_DECL aegis::future<rest::rest_reply> guild::get_guild_invites()
+AEGIS_DECL aegis::future<gateway::objects::invite> guild::get_guild_invite(std::string invite_code)
+{
+#if !defined(AEGIS_DISABLE_ALL_CACHE)
+    if (!perms().can_manage_guild())
+        return aegis::make_exception_future<gateway::objects::invite>(error::no_permission);
+#endif
+
+    return _bot->get_ratelimit().post_task<gateway::objects::invite>({ fmt::format("/invites/{}", invite_code), rest::Get });
+}
+
+AEGIS_DECL aegis::future<gateway::objects::invites> guild::get_guild_invites()
+{
+#if !defined(AEGIS_DISABLE_ALL_CACHE)
+    if (!perms().can_manage_guild())
+        return aegis::make_exception_future<gateway::objects::invites>(error::no_permission);
+#endif
+
+    return _bot->get_ratelimit().post_task<gateway::objects::invites>({ fmt::format("/guilds/{}/invites", guild_id), rest::Get });
+}
+
+AEGIS_DECL aegis::future<rest::rest_reply> guild::delete_guild_invite(std::string invite_code)
 {
 #if !defined(AEGIS_DISABLE_ALL_CACHE)
     if (!perms().can_manage_guild())
         return aegis::make_exception_future(error::no_permission);
 #endif
 
-    return aegis::make_exception_future(error::not_implemented);
+    return _bot->get_ratelimit().post_task({ fmt::format("/invites/{}", invite_code), rest::Delete });
 }
 
 /**\todo Incomplete. Signature may change


### PR DESCRIPTION
Created both an "invite" and "invites" gateway object, created `get_guild_invite`, `get_guild_invites`, and `delete_guild_invite`, and finished the implementation of the "emoji" object along with `get_emojis` and `get_emojis_nocopy` methods.

Only thing missing is an implementation of invite-related events, which I would be happy to add in a future PR.