### PR TITLE
Add AEGIS_DECL to perm_strs for dynamic lib compatibility

### DIFF
--- a/include/aegis/impl/permission.cpp
+++ b/include/aegis/impl/permission.cpp
@@ -30,7 +30,7 @@ AEGIS_DECL void to_json(nlohmann::json& j, const permission& s)
 }
 /// \endcond
 
-const std::unordered_map<int64_t, const std::string> permission::perm_strs {
+AEGIS_DECL const std::unordered_map<int64_t, const std::string> permission::perm_strs {
     {0x1, "Create invites"},
     {0x2, "Kick members"},
     {0x4, "Ban members"},

--- a/include/aegis/permission.hpp
+++ b/include/aegis/permission.hpp
@@ -152,7 +152,7 @@ public:
 
 private:
     int64_t _allow_permissions = 0;
-    static const std::unordered_map<int64_t, const std::string> perm_strs;
+    AEGIS_DECL static const std::unordered_map<int64_t, const std::string> perm_strs;
 };
 
 /// \cond TEMPLATES


### PR DESCRIPTION
Somehow missed this before due to a custom implementation.