### PR TITLE
url_encode can break already encoded data

### DIFF
--- a/include/aegis/utility.hpp
+++ b/include/aegis/utility.hpp
@@ -184,6 +184,10 @@ inline std::chrono::system_clock::time_point from_http_date(const std::string & 
 
 inline std::string url_encode(const std::string & value)
 {
+    if (value.find('%') != std::string::npos) { // already encoded
+        return value;
+    }
+
     std::ostringstream escaped;
     escaped.fill('0');
     escaped << std::hex;


### PR DESCRIPTION
A simple find for % should let projects that already do that to work again. Right now if a encoded string goes there, it doesn't work.