### PR TITLE
Fix GCC 11 build

### DIFF
--- a/include/aegis/user.hpp
+++ b/include/aegis/user.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <set>
 #include <shared_mutex>
+#include <mutex>
 
 namespace aegis
 {


### PR DESCRIPTION
As of GCC version 11, some header dependencies changed[1] and this project no longer builds due to a missing `<mutex>` include for `std::unique_lock`.

[1] https://www.gnu.org/software/gcc/gcc-11/porting_to.html