### PR TITLE
ratelimit/bucket.hpp: Add missing include

### DIFF
--- a/include/aegis/ratelimit/bucket.hpp
+++ b/include/aegis/ratelimit/bucket.hpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <queue>
 #include <atomic>
+#include <thread>
 #include <spdlog/spdlog.h>
 
 namespace aegis


### PR DESCRIPTION
bucket.hpp missed a required #include <thread>. This sometimes causes
build errors when including bucket.hpp in another project directly
instead of using the convenience header. This commit fixes this by
explicitly including <thread>.

Signed-off-by: NexAdn <nex@nexadn.de>